### PR TITLE
Add FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,9 @@ This project implements a basic structure for an AI driven crypto trading bot as
    ```bash
    python run_bot.py
    ```
+4. Launch the API server with FastAPI and Uvicorn:
+   ```bash
+   uvicorn server:app --reload
+   ```
 
 The bot is minimal and intended for educational use. Extend modules under `src/` to implement full functionality according to the design specification.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ ta>=0.11.0
 python-dotenv>=1.0.0
 langchain>=0.1.0
 openai>=1.0.0
+fastapi>=0.104.0
+uvicorn>=0.23.0

--- a/run_bot.py
+++ b/run_bot.py
@@ -31,7 +31,7 @@ def append_ticker(df: pd.DataFrame, ticker: dict) -> pd.DataFrame:
                       'volume': ticker.get('baseVolume', 0)}, ignore_index=True)
 
 
-async def main():
+async def run_bot():
     cfg = load_config()
 
     exchange = ccxt.phemex({'apiKey': cfg.exchange.api_key, 'secret': cfg.exchange.api_secret})
@@ -59,6 +59,10 @@ async def main():
         await asyncio.sleep(1)
 
     await executor.close()
+
+
+async def main():
+    await run_bot()
 
 
 if __name__ == '__main__':

--- a/server.py
+++ b/server.py
@@ -1,0 +1,33 @@
+import asyncio
+from fastapi import FastAPI
+
+from run_bot import run_bot
+
+app = FastAPI()
+
+bot_task: asyncio.Task | None = None
+
+@app.post("/start")
+async def start_trading():
+    global bot_task
+    if bot_task is None or bot_task.done():
+        bot_task = asyncio.create_task(run_bot())
+        return {"status": "started"}
+    return {"status": "already running"}
+
+@app.post("/stop")
+async def stop_trading():
+    global bot_task
+    if bot_task is not None and not bot_task.done():
+        bot_task.cancel()
+        try:
+            await bot_task
+        except asyncio.CancelledError:
+            pass
+        return {"status": "stopped"}
+    return {"status": "not running"}
+
+@app.get("/status")
+async def status():
+    running = bot_task is not None and not bot_task.done()
+    return {"running": running}


### PR DESCRIPTION
## Summary
- expose trading bot via FastAPI server
- add instructions to README for running the server
- update requirements with FastAPI and Uvicorn
- refactor `run_bot.py` to expose `run_bot` function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68548a7e9e1c8327aa93467cdf4dae13