### PR TITLE
Fix missing langchain-community dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This project implements a basic structure for an AI driven crypto trading bot as
 
 ## Setup
 1. Copy `.env.example` to `.env` and fill in API keys.
-2. Install requirements:
+2. Install requirements (note that `langchain-community` has been added to
+   provide chat model integrations):
    ```bash
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pandas>=2.0.0
 ta>=0.11.0
 python-dotenv>=1.0.0
 langchain>=0.1.0
+langchain-community>=0.0.5
 openai>=1.0.0
 fastapi>=0.104.0
 uvicorn>=0.23.0


### PR DESCRIPTION
## Summary
- add `langchain-community` requirement
- note the new dependency in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68548c0ecd288327b979dc076e6fd9d0